### PR TITLE
Fixed a bug in join

### DIFF
--- a/BlockStreamIterator/ParallelBlockStreamIterator/BlockStreamExpander.cpp
+++ b/BlockStreamIterator/ParallelBlockStreamIterator/BlockStreamExpander.cpp
@@ -298,7 +298,7 @@ bool BlockStreamExpander::createNewExpandedThread(){
 		thread_count_++;
 		lock_.release();
 	//	in_work_expanded_thread_list_.insert(tid);
-		printf("Expand time :%lf \n",getSecond(start));
+//		printf("Expand time :%lf \n",getSecond(start));
 		return true;
 	}
 	else{
@@ -420,7 +420,7 @@ bool BlockStreamExpander::Shrink(){
 //		in_work_expanded_thread_list_.erase(cencel_thread_id);
 		lock_.release();
 		this->terminateExpandedThread(cencel_thread_id);
-		printf("\n\nShrink time :%f\t %ld cycles \n\n",getSecond(start),curtick()-start);
+//		printf("\n\nShrink time :%f\t %ld cycles \n\n",getSecond(start),curtick()-start);
 		return true;
 	}
 //	lock_.release();

--- a/Server.cpp
+++ b/Server.cpp
@@ -20,7 +20,8 @@ struct option long_options[] = {
    {"init-dop",required_argument,0,257},
    {"max-dop",required_argument,0,258},
    {"datadir",required_argument,0,259},
-   {"scheduler_cycle",required_argument,0,260}
+   {"scheduler_cycle",required_argument,0,260},
+   {nullptr,0,0,0}
  };
 
 std::string help_info=std::string("-c --config-file FILE_NAME\n\t\t Specify the configure file\n")+

--- a/Test/gtest_main.cpp
+++ b/Test/gtest_main.cpp
@@ -13,7 +13,8 @@ static int consumed_args=0;
 struct option long_options[] = {
    {"help",no_argument,0,'h'},
    {"ip", required_argument, 0, 256},
-   {"port", required_argument, 0, 257}
+   {"port", required_argument, 0, 257},
+   {nullptr, 0, 0, 0}
  };
 
 
@@ -30,7 +31,7 @@ std::string help_info=std::string("")+
 void handle_parameters(int argc, char** argv){
 	optind=0;
 	int opt;
-	while ((opt = getopt_long(argc, argv, "c:h", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "h", long_options, NULL)) != -1) {
 		switch (opt) {
 		case 256:
 			ElasticIteratorModelTest::ip_=(std::string(optarg));
@@ -44,6 +45,7 @@ void handle_parameters(int argc, char** argv){
 			printf("%s",help_info.c_str());
 			break;
 		default:
+			printf("Invalid parameters! Try -h for help\n");
 			break;
 		}
 	}


### PR DESCRIPTION
Hash table is carelessly deleted at the end of join open, and consequently causes segmentation fault when accessing hash table in open.